### PR TITLE
Fix error in projecting distributions

### DIFF
--- a/c51_ddqn.py
+++ b/c51_ddqn.py
@@ -172,16 +172,16 @@ class C51Agent:
                 # Distribution collapses to a single point
                 Tz = min(self.v_max, max(self.v_min, reward[i]))
                 bj = (Tz - self.v_min) / self.delta_z 
-                m_l, m_u = math.floor(bj), math.ceil(bj)
+                m_l, m_u = math.floor(bj), math.floor(bj) + 1
                 m_prob[action[i]][i][int(m_l)] += (m_u - bj)
-                m_prob[action[i]][i][int(m_u)] += (bj - m_l)
+                m_prob[action[i]][i][min(int(m_u), self.num_atoms - 1)] += (bj - m_l)
             else:
                 for j in range(self.num_atoms):
                     Tz = min(self.v_max, max(self.v_min, reward[i] + self.gamma * self.z[j]))
                     bj = (Tz - self.v_min) / self.delta_z 
-                    m_l, m_u = math.floor(bj), math.ceil(bj)
+                    m_l, m_u = math.floor(bj), math.floor(bj) + 1
                     m_prob[action[i]][i][int(m_l)] += z_[optimal_action_idxs[i]][i][j] * (m_u - bj)
-                    m_prob[action[i]][i][int(m_u)] += z_[optimal_action_idxs[i]][i][j] * (bj - m_l)
+                    m_prob[action[i]][i][min(int(m_u), self.num_atoms - 1)] += z_[optimal_action_idxs[i]][i][j] * (bj - m_l)
 
         loss = self.model.fit(state_inputs, m_prob, batch_size=self.batch_size, nb_epoch=1, verbose=0)
 


### PR DESCRIPTION
This is the same issue as fixed in https://github.com/Curt-Park/rainbow-is-all-you-need/pull/76 which is due to `math.floor(bj)` and `math.ceil(bj)` both returning the same value when `bj` has an integer value, which can cause holes to appear in the projected distribution. Using `math.floor(bj) + 1` instead of `math.ceil(bj)` guarantees that `m_u` will be equal to `m_l + 1`, but requires clamping `m_u` to `num_atoms - 1` when using it to index the distribution atoms.

Please note that I have not tested this specific implementation, so you should probably at least check that this runs properly before merging it. I have however tested it with my own Rainbow implementation (in PyTorch), which made my agent perform a lot better compared to before implementing the fix.